### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/validate-nuget-package.yml
+++ b/.github/workflows/validate-nuget-package.yml
@@ -7,6 +7,9 @@ on:
     branches: [ "main" ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/MarcWils/VECOZO-OpenAPI/security/code-scanning/2](https://github.com/MarcWils/VECOZO-OpenAPI/security/code-scanning/2)

To fix the issue, add a `permissions` block at the root of the workflow file to explicitly define the permissions required. Based on the workflow's steps, it primarily reads repository contents (e.g., checking out code and restoring dependencies) and does not perform any write operations. Therefore, the minimal required permission is `contents: read`. This change ensures that the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
