### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pack-and-release-nuget-package.yml
+++ b/.github/workflows/pack-and-release-nuget-package.yml
@@ -1,5 +1,9 @@
 name: Pack & release NuGet package
 
+permissions:
+  contents: read
+  packages: write
+
 on:
   workflow_dispatch:
 


### PR DESCRIPTION
Potential fix for [https://github.com/MarcWils/VECOZO-OpenAPI/security/code-scanning/1](https://github.com/MarcWils/VECOZO-OpenAPI/security/code-scanning/1)

To fix the issue, add a `permissions` block at the root of the workflow file to explicitly define the minimal permissions required. Based on the workflow's steps, the following permissions are necessary:
- `contents: read` for accessing the repository's contents.
- `packages: write` for publishing the NuGet package.

This ensures that the workflow has only the permissions it needs to function correctly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
